### PR TITLE
Added code to pass empty string if CFBundleDisplayName is nil.

### DIFF
--- a/ParselyiOS/ParselyTracker.m
+++ b/ParselyiOS/ParselyTracker.m
@@ -230,7 +230,10 @@ ParselyTracker *instance;  /*!< Singleton instance */
 -(NSMutableDictionary *)collectDeviceInfo{
     NSMutableDictionary *dInfo = [NSMutableDictionary dictionary];
     
-    [dInfo setObject:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] forKey:@"appname"];
+//    [dInfo setObject:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] forKey:@"appname"];
+	NSString *bundleDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+	[dInfo setObject:(bundleDisplayName ? bundleDisplayName : @"") forKey:@"appname"];
+
     [dInfo setObject:[self getSiteUuid] forKey:@"parsely_site_uuid"];
     [dInfo setObject:self.apiKey forKey:@"idsite"];
     


### PR DESCRIPTION
Made changes required to prevent app from aborting due to nil value of CFBundleDisplayName.  CFBundleDisplayName, per Apple's recommendation, is only populated if there will be localizations of the app.
