### PR TITLE
Add nil checks and count > 0 checks

### DIFF
--- a/HiParsely/HiParsely/ViewController.m
+++ b/HiParsely/HiParsely/ViewController.m
@@ -69,15 +69,9 @@
 -(void)toggleSimulatedConnection{
     if(hasConnection){
         hasConnection = NO;
-#ifdef PARSELY_DEBUG
-        [[ParselyTracker sharedInstance] __debugWifiOff];
-#endif
         [connectionButton setTitle:@"Regain connection" forState:UIControlStateNormal];
     } else {
         hasConnection = YES;
-#ifdef PARSELY_DEBUG
-        [[ParselyTracker sharedInstance] __debugWifiOn];
-#endif
         [connectionButton setTitle:@"Lose connection" forState:UIControlStateNormal];
     }
 }

--- a/ParselyiOS/ParselyTracker.m
+++ b/ParselyiOS/ParselyTracker.m
@@ -163,8 +163,9 @@ ParselyTracker *instance;  /*!< Singleton instance */
 }
 
 -(NSArray *)getStoredQueue{
-    if([[NSUserDefaults standardUserDefaults] objectForKey:storageKey] != nil) {
-        return [[NSUserDefaults standardUserDefaults] objectForKey:storageKey];
+    id object = [[NSUserDefaults standardUserDefaults] objectForKey:storageKey];
+    if(![object isEqual:nil]){
+        return object;
     }
     return [NSArray array];
 }

--- a/ParselyiOS/ParselyTracker.m
+++ b/ParselyiOS/ParselyTracker.m
@@ -104,6 +104,9 @@ ParselyTracker *instance;  /*!< Singleton instance */
 }
 
 -(void)sendBatchRequest:(NSSet *)queue{
+    if([queue count] < 1) {
+        return;
+    }
     // create an efficiently packed object for the GET parameters
     NSMutableDictionary *batchDict = [NSMutableDictionary dictionary];
     NSArray *queueArray = [queue allObjects];
@@ -160,7 +163,10 @@ ParselyTracker *instance;  /*!< Singleton instance */
 }
 
 -(NSArray *)getStoredQueue{
-    return [[NSUserDefaults standardUserDefaults] objectForKey:storageKey];
+    if([[NSUserDefaults standardUserDefaults] objectForKey:storageKey] != nil) {
+        return [[NSUserDefaults standardUserDefaults] objectForKey:storageKey];
+    }
+    return [NSArray array];
 }
 
 -(NSString *)getSiteUuid{


### PR DESCRIPTION
- This also removes to ifdefs that were causing the build to fail
because they weren't defined in the interface or used anywhere in the
codebase.

@emmett9001 I'm not very familiar with objective c so please let me know if this is bad.

The nil check is my attempt to fix this:
```
#0. Crashed: com.apple.main-thread
0  libobjc.A.dylib                0x190456f70 objc_msgSend + 16
1  CoreFoundation                 0x1918f0654 -[__NSSetM addObject:] + 260
2  CoreFoundation                 0x191900770 -[NSMutableSet addObjectsFromArray:] + 520
3  thirtythreeten                 0x1000b0550 -[ParselyTracker persistQueue] (ParselyTracker.m:144)
4  CoreFoundation                 0x1919a6b10 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
5  CoreFoundation                 0x1919a6214 _CFXRegistrationPost + 400
6  CoreFoundation                 0x1919a5f90 ___CFXNotificationPost_block_invoke + 60
7  CoreFoundation                 0x191a15b8c -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1504
8  CoreFoundation                 0x1918e7e64 _CFXNotificationPost + 376
9  Foundation                     0x19241ce0c -[NSNotificationCenter postNotificationName:object:userInfo:] + 68
10 UIKit                          0x19794e73c -[UIApplication _terminateWithStatus:] + 300
11 UIKit                          0x197b507cc __102-[UIApplication _handleApplicationDeactivationWithScene:shouldForceExit:transitionContext:completion:]_block_invoke.2100 + 792
12 UIKit                          0x197b53fdc _runAfterCACommitDeferredBlocks + 292
13 UIKit                          0x197b45d50 _cleanUpAfterCAFlushAndRunDeferredBlocks + 560
14 UIKit                          0x1978b50b4 _afterCACommitHandler + 168
15 CoreFoundation                 0x1919ba0c0 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 32
16 CoreFoundation                 0x1919b7cf0 __CFRunLoopDoObservers + 372
17 CoreFoundation                 0x1919b8180 __CFRunLoopRun + 1024
18 CoreFoundation                 0x1918e62b8 CFRunLoopRunSpecific + 444
19 GraphicsServices               0x19339a198 GSEventRunModal + 180
20 UIKit                          0x19792d7fc -[UIApplication _run] + 684
21 UIKit                          0x197928534 UIApplicationMain + 208
22 thirtythreeten                 0x1000b54cc main (main.m:16)
23 libdispatch.dylib              0x1908c95b8 (Missing)
```

Apparently getObjectForKey will return nil if the object doesn't exist and then we're trying to turn a nil into a set with addObjectsFromArray and I don't believe that'll turn out okay. I'm just returning an empty array. There also appears to be [a bug](https://stackoverflow.com/questions/41756036/nsuserdefaults-objectforkey-sometimes-nil) in iOS 10 where it will just return nil when it feels like it.

The count < 1 check is my attempt at short circuiting the logic before it tries to do `[queueArray objectAtIndex:0]` on an empty queueArray. This was shown in the iOS1 stack trace in the [original ticket](https://github.com/Parsely/web/issues/7005#issuecomment-344055353).

Again, I don't think these things should happen unless there are threading issues. It seems like the whole process of batching events won't even start until there are events in the queue. This seems to me like it's a `do no harm` fix at least. 

I took out the things in the ifdefs because the project wouldn't build while they were there. I tried adding them to the interface and then it complained that they weren't being used so I removed them.

I spent most of the day trying to convert the unit tests to the new XCTest framework (we're apparently two whole test frameworks behind the current) and once it got closer to the end of the day I tossed that work in a branch and went back to trying to fix the bug I was trying to fix. I can push that branch up. There's something in the build settings that I've not got right. I moved everything over and tried to mirror the build settings but it was complaining that a bunch of `UI*` things weren't available.